### PR TITLE
chore: README changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
 # tinyboot
 
-Tinyboot is a linuxboot kexec bootloader for coreboot. Boot configuration is
-done with the [Boot Loader Specification]
-(https://uapi-group.org/specifications/specs/boot_loader_specification/). The
-nix flake provides coreboot builds for a few boards, contributions for more
-configs are welcome!
+## Description
+
+[`Tinyboot`](https://github.com/jmbaur/tinyboot) is a
+[`LinuxBoot`](https://www.linuxboot.org/) `kexec` bootloader for
+[`coreboot`](https://www.coreboot.org/). Boot configuration is done with the
+[Boot Loader
+Specification](https://uapi-group.org/specifications/specs/boot_loader_specification/).
+
+The `nix` flake provides `coreboot` builds for a few boards. Contributions for
+more configs are welcome!
 
 ## Usage
 


### PR DESCRIPTION
# Description
I was taking a look at this project and thought I'd rake through the README. Please consider the change set. I tried to address:
1. Repairing the external URL to the UAPI Group's Boot Loader Spec.
1. Code spans for project names ("proper nouns")
1. Adding a subsection for the description/overview content.

Please note that the `flake` URL no longer seems to resolve to any buildable (tested with a few different board attributes):
```
$ nix build .\#coreboot.qemu-aarch64.config.build.<tab><tab>
.\#coreboot.qemu-aarch64.config.build.baseInitrd
.\#coreboot.qemu-aarch64.config.build.coreboot  
.\#coreboot.qemu-aarch64.config.build.firmware  
.\#coreboot.qemu-aarch64.config.build.fitImage  
.\#coreboot.qemu-aarch64.config.build.initrd    
.\#coreboot.qemu-aarch64.config.build.linux     
.\#coreboot.qemu-aarch64.config.build.qemuScript
.\#coreboot.qemu-aarch64.config.build.testScript
```

Maybe it's obvious how to change the `Usage` section but I wasn't sure how to amend it.